### PR TITLE
Add Travis and Ganache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+dist: trusty
+sudo: required
+language: node_js
+
+cache:
+  directories:
+    - node_modules
+  
+install:
+  - npm install --silent
+
+jobs:
+  include:
+    - stage: test
+      script: npm run test
+
+notifications:
+  email:
+    on_success: never
+    on_failure: never
+    

--- a/Testing/__tests__/Contract/ContractInstance.spec.ts
+++ b/Testing/__tests__/Contract/ContractInstance.spec.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js';
 import { ISimpleContract, ISimpleContractConnected, IComplexContract, IComplexContractConnected } from '../../contracts/abiTypes';
 import { ProxiedNode, CreateContract, ContractInstance } from '../../../src/lib';
 import { simpleContractBytecode, complexContractBytecode } from '../../contracts'
-import { startServer, stopServer, TEST_ETH_ADDRESS, TEST_SERVER_ENDPOINT } from '../../helpers';
+import { startServer, stopServer, TEST_ETH_ADDRESS_A, TEST_SERVER_ENDPOINT } from '../../helpers';
 
 const simpleContractAbi = require('../../contracts/simple/SimpleContract.json');
 const complexContractAbi = require('../../contracts/complex/ComplexContract.json')
@@ -61,7 +61,7 @@ describe('contract instantiation', async () => {
     const testAbi = complexContractAbi;
     const testContract = CreateContract<IComplexContract>(testAbi)
     const testInstance = await ContractInstance<IComplexContractConnected>(testContract, testNode, {parameters: {arg0: uintArgument, arg1: bytesArgument}, txObj: {data: complexContractBytecode, from: addresses[0], gas: '90000'}})
-    await testInstance.sendFunction0({arg0: uintArgument}, {from: TEST_ETH_ADDRESS, gas: '90000'})
+    await testInstance.sendFunction0({arg0: uintArgument}, {from: TEST_ETH_ADDRESS_A, gas: '90000'})
     expect((await testInstance.a())[0]).toEqual(uintArgument.toString())
     expect((await testInstance.b())[0]).toEqual(bytesArgument)
   })

--- a/Testing/helpers.ts
+++ b/Testing/helpers.ts
@@ -1,6 +1,9 @@
 
-export const TEST_ETH_ADDRESS = '0x2eD1f9A7A7b8A30fb2f9150A81A87fdeb7ae5Cd2'
-export const TEST_ETH_PKEY = '0x790c621f4df1a3bc6046121637d21f7dad77c31c504f2f8df762aaf60949991f'
+export const TEST_ETH_PKEY_A = '0x790c621f4df1a3bc6046121637d21f7dad77c31c504f2f8df762aaf60949991f';
+export const TEST_ETH_PKEY_B = '0xc4a2d3a38f825d58756110605cb8b3fc85f62d40e71a230636f8e11a9680430c';
+export const TEST_ETH_ADDRESS_A = '0x2eD1f9A7A7b8A30fb2f9150A81A87fdeb7ae5Cd2';
+export const TEST_ETH_ADDRESS_B = '0xe024F80675f9CF3b720727aBF0Df0af6cDEEe7D4';
+
 export const TEST_SERVER_ENDPOINT = 'http://localhost:8545'
 
 const ganache = require('ganache-cli');
@@ -8,11 +11,15 @@ const ganache = require('ganache-cli');
 const serverParams = {
   port: 8545,
   accounts: [{
-    secretKey: TEST_ETH_PKEY,
+    secretKey: TEST_ETH_PKEY_A,
+    balance: '0x56bc75e2d63100000' // 100 ether
+  },{
+    secretKey: TEST_ETH_PKEY_B,
     balance: '0x56bc75e2d63100000' // 100 ether
   }],
   unlocked_accounts: [
-    '0x2eD1f9A7A7b8A30fb2f9150A81A87fdeb7ae5Cd2'
+    TEST_ETH_ADDRESS_A,
+    TEST_ETH_ADDRESS_B
   ],
   total_accounts: 0 //generate no random accounts
 }

--- a/Testing/helpers.ts
+++ b/Testing/helpers.ts
@@ -1,0 +1,37 @@
+
+export const TEST_ETH_ADDRESS = '0x2eD1f9A7A7b8A30fb2f9150A81A87fdeb7ae5Cd2'
+export const TEST_ETH_PKEY = '0x790c621f4df1a3bc6046121637d21f7dad77c31c504f2f8df762aaf60949991f'
+export const TEST_SERVER_ENDPOINT = 'http://localhost:8545'
+
+const ganache = require('ganache-cli');
+
+const serverParams = {
+  port: 8545,
+  accounts: [{
+    secretKey: TEST_ETH_PKEY,
+    balance: '0x56bc75e2d63100000' // 100 ether
+  }],
+  unlocked_accounts: [
+    '0x2eD1f9A7A7b8A30fb2f9150A81A87fdeb7ae5Cd2'
+  ],
+  total_accounts: 0 //generate no random accounts
+}
+const ganacheServer = ganache.server(serverParams);
+
+export const startServer = () => new Promise((resolve, reject) => {
+  ganacheServer.listen(serverParams.port, (err: any) => {
+    if (err) {
+      return reject(err)
+    }
+    resolve();
+  })
+});
+
+export const stopServer = () => new Promise((resolve, reject) => {
+  ganacheServer.close((err: any) => {
+    if (err) {
+      return reject(err)
+    }
+    resolve();
+  })
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ethereumjs-abi": "0.6.4",
     "ethjs-util": "0.1.4",
     "fetch": "1.1.0",
+    "ganache-cli": "^6.1.0",
     "node-fetch": "1.7.3",
     "npm": "^5.7.1",
     "rlp": "2.0.0",


### PR DESCRIPTION
To summarize: 

 - Adds a basic Travis config file
 - Starts and stops a `ganache-cli` test RPC server before every test suite
 - Slight refactoring to make tests pass

I haven't tested the `.travis.yml` file, but it's a pretty simple config that was based off of MyCrypto's.